### PR TITLE
Remove deprecated JSHint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,7 +15,5 @@
   "undef": true,
   "unused": true,
   "strict": true,
-  "trailing": true,
-  "smarttabs": true,
   "white": true
 }


### PR DESCRIPTION
Both are deprecated since jshint v2.5.
