### PR TITLE
Sudo :-1:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
   - 'iojs'


### PR DESCRIPTION
Prefixing npm with `sudo` can be dangerous. You'd better read https://docs.npmjs.com/getting-started/fixing-npm-permissions.